### PR TITLE
Fixed link to developer manual

### DIFF
--- a/manual/user_manual/running_limes.md
+++ b/manual/user_manual/running_limes.md
@@ -29,6 +29,6 @@ The jar will be placed in `limes-gui/limes-gui/target/jfx/app/`
 The `limes-gui/target/jfx/app/lib` folder needs to be in the same folder as the .jar for the .jar to work!
 
 ## From Java
-See [Developer manual](https://github.com/AKSW/LIMES-dev/blob/dev/limes-core/manual/developer_manual/index.md)
+See [Developer manual](/LIMES/developer_manual/)
 
 


### PR DESCRIPTION
The page with the broken link is http://dice-group.github.io/LIMES/user_manual/running_limes.html

The final link "Developer manual" at the bottom of the page points to https://github.com/dice-group/LIMES/blob/dev/limes-core/manual/developer_manual/index.md instead of http://dice-group.github.io/LIMES/developer_manual/