### PR TITLE
Fixed issue with Flink because of using static variables.

### DIFF
--- a/limes-core/pom.xml
+++ b/limes-core/pom.xml
@@ -231,12 +231,13 @@
                                 implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                <mainClass>org.aksw.limes.core.measures.mapper.space.Flink.PerformanceEval</mainClass>
                             <manifestEntries>
-                                <X-Compile-Source-JDK>${maven.compile.source}</X-Compile-Source-JDK>
-                                <X-Compile-Target-JDK>${maven.compile.target}</X-Compile-Target-JDK>
+                                <X-Compile-Source-JDK>${maven.compiler.source}</X-Compile-Source-JDK>
+                                <X-Compile-Target-JDK>${maven.compiler.target}</X-Compile-Target-JDK>
                             </manifestEntries>
                         </transformer>
-                     <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" /> </transformers>
-                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                     <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                    </transformers>
+
                 </configuration>
             </plugin>
 
@@ -391,17 +392,17 @@
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-java</artifactId>
-			<version>1.3.2</version>
+			<version>1.4.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-streaming-java_2.10</artifactId>
-			<version>1.3.2</version>
+			<artifactId>flink-streaming-java_2.11</artifactId>
+			<version>1.4.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-clients_2.10</artifactId>
-			<version>1.3.2</version>
+			<artifactId>flink-clients_2.11</artifactId>
+			<version>1.4.2</version>
 		</dependency>
 
 

--- a/limes-core/src/main/java/org/aksw/limes/core/measures/mapper/space/Flink/PerformanceEval.java
+++ b/limes-core/src/main/java/org/aksw/limes/core/measures/mapper/space/Flink/PerformanceEval.java
@@ -40,7 +40,6 @@ public class PerformanceEval {
 	}
 	
 	private static DataSet<Instance> readInstancesFromCSV(String path){
-		System.out.println(path);
 		DataSet<Tuple3<String,Double,Double>> lines = (DataSet<Tuple3<String, Double, Double>>) env.readCsvFile(path).ignoreFirstLine().types(String.class, Double.class, Double.class);
 		return lines.map(line -> {
 			Instance i = new Instance(line.f0);
@@ -56,19 +55,23 @@ public class PerformanceEval {
             PrintWriter resWriter = new PrintWriter(new FileOutputStream("FlinkHR3Eval.csv"));
             resWriter.write("Iteration\tFlink\n");
             resWriter.close();
+
             FlinkHR3Mapper flinkhr3m = new FlinkHR3Mapper();
             for(int i = 0; i < 10; i++){
                 resWriter = new PrintWriter(new FileOutputStream("FlinkHR3Eval.csv", true));
                 long start = System.currentTimeMillis();
+
                 AMapping links = flinkhr3m.getMapping(sourceDS, targetDS, "?x", "?y", measureExpr, 0.9);
                 long finish = System.currentTimeMillis();
                 long flinkhr3res = finish - start;
-                logger.error("link size: " + links.size());
+                logger.info("link size: " + links.size());
                 resWriter.write(i + "\t" + flinkhr3res + "\n");
                 resWriter.close();
                 CSVMappingWriter linkWriter = new CSVMappingWriter();
                 linkWriter.write(links, "FlinkHR3links.csv");
-                logger.info("\n\n ====Comparisons: " + FlinkHR3Mapper.comparisons + "\n\n");
+                int comparisons = env.getLastJobExecutionResult().getAccumulatorResult("comparisons");
+                logger.info("\n\n ====Comparisons: " + comparisons + "\n\n");
+                System.out.println("\n\n ====Comparisons: " + comparisons + "\n\n");
             }
 	}
 }


### PR DESCRIPTION
Using static variables doesn't work when using them in methods/classes which will be used in Flink jobs that will be distributed to workers. The reasoner for is that a copy of the class will be made, thus, any information in static class variables will be lost, thus, `int` variables are 0, lists are empty, etc.
Best practice is to pass necessary arguments to the objects itself, e.g. via the constructor.

Regarding static counters variables, etc.: Flink provides so-called accumulators, please have a look at the documentation.

Hope this helps.