### PR TITLE
Hotfix Wombat -> 1.6.2

### DIFF
--- a/limes-core/pom.xml
+++ b/limes-core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.aksw.limes</groupId>
         <artifactId>limes-full</artifactId>
-        <version>1.6.2-SNAPSHOT</version>
+        <version>1.6.2</version>
     </parent>
 
     <build>

--- a/limes-core/pom.xml
+++ b/limes-core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.aksw.limes</groupId>
         <artifactId>limes-full</artifactId>
-        <version>1.6.2</version>
+        <version>1.6.3-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/limes-core/src/main/java/org/aksw/limes/core/datastrutures/LogicOperator.java
+++ b/limes-core/src/main/java/org/aksw/limes/core/datastrutures/LogicOperator.java
@@ -1,5 +1,5 @@
 package org.aksw.limes.core.datastrutures;
 
 public enum LogicOperator {
-    AND, OR, MINUS, DIFF, XOR
+    AND, OR, MINUS, XOR
 }

--- a/limes-debian-cli/pom.xml
+++ b/limes-debian-cli/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.aksw.limes</groupId>
 		<artifactId>limes-full</artifactId>
-		<version>1.6.2-SNAPSHOT</version>
+		<version>1.6.2</version>
 	</parent>
 
 	<artifactId>limes-debian-cli</artifactId>
@@ -153,7 +153,7 @@
 		<dependency>
 			<groupId>org.aksw.limes</groupId>
 			<artifactId>limes-core</artifactId>
-			<version>1.6.2-SNAPSHOT</version>
+			<version>1.6.2</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/limes-debian-cli/pom.xml
+++ b/limes-debian-cli/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.aksw.limes</groupId>
 		<artifactId>limes-full</artifactId>
-		<version>1.6.2</version>
+		<version>1.6.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>limes-debian-cli</artifactId>
@@ -153,7 +153,7 @@
 		<dependency>
 			<groupId>org.aksw.limes</groupId>
 			<artifactId>limes-core</artifactId>
-			<version>1.6.2</version>
+			<version>1.6.3-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/limes-gui/pom.xml
+++ b/limes-gui/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.aksw.limes</groupId>
         <artifactId>limes-full</artifactId>
-        <version>1.6.2</version>
+        <version>1.6.3-SNAPSHOT</version>
     </parent>
 
     <build>
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.aksw.limes</groupId>
             <artifactId>limes-core</artifactId>
-            <version>1.6.2</version>
+            <version>1.6.3-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/limes-gui/pom.xml
+++ b/limes-gui/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.aksw.limes</groupId>
         <artifactId>limes-full</artifactId>
-        <version>1.6.2-SNAPSHOT</version>
+        <version>1.6.2</version>
     </parent>
 
     <build>
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.aksw.limes</groupId>
             <artifactId>limes-core</artifactId>
-            <version>1.6.2-SNAPSHOT</version>
+            <version>1.6.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/manual/user_manual/configuration_file/defining_link_specifications.md
+++ b/manual/user_manual/configuration_file/defining_link_specifications.md
@@ -36,7 +36,7 @@ We call `trigrams(x.rdfs:label,y.dc:title)|0.3` the left child of the specificat
 
 ## Boolean operations
 
-Boolean operations allow to combine and filter the results of metric operations and include `AND`, `OR`, `DIFF`, e.g. as `AND(trigrams(x.rdfs:label,y.dc:title)|0.9, euclidean(x.lat|x.long, y.latitude|y.longitude)|0.7)`.
+Boolean operations allow to combine and filter the results of metric operations and include `AND`, `OR`, `MINUS`, e.g. as `AND(trigrams(x.rdfs:label,y.dc:title)|0.9, euclidean(x.lat|x.long, y.latitude|y.longitude)|0.7)`.
     
 This specification returns all links such that:
     

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<groupId>org.aksw.limes</groupId>
 	<artifactId>limes-full</artifactId>
-	<version>1.6.2-SNAPSHOT</version>
+	<version>1.6.2</version>
 	<name>LIMES</name>
 	<description>LIMES – Link Discovery Framework for Metric Spaces.</description>
 	<url>http://aksw.org/Projects/LIMES</url>
@@ -24,7 +24,7 @@
     <scm>
         <url>https://github.com/dice-group/LIMES</url>
         <connection>scm:git:https://github.com/dice-group/LIMES.git</connection>
-        <tag>HEAD</tag>
+        <tag>1.6.2</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<groupId>org.aksw.limes</groupId>
 	<artifactId>limes-full</artifactId>
-	<version>1.6.2</version>
+	<version>1.6.3-SNAPSHOT</version>
 	<name>LIMES</name>
 	<description>LIMES – Link Discovery Framework for Metric Spaces.</description>
 	<url>http://aksw.org/Projects/LIMES</url>
@@ -24,7 +24,7 @@
     <scm>
         <url>https://github.com/dice-group/LIMES</url>
         <connection>scm:git:https://github.com/dice-group/LIMES.git</connection>
-        <tag>1.6.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
 


### PR DESCRIPTION
Removed operator `DIFF` in `LogicOperator` to reflect the set of legal operators as defined in the Planners and Rewriters that did not consider this operator legal and hence threw confusing errors when Wombat did learn a LS with 'DIFF' and consequently tried to apply it.
