### PR TITLE
In documentation: fix URL that ended in 404

### DIFF
--- a/docs/user_manual/configuration_file/index.md
+++ b/docs/user_manual/configuration_file/index.md
@@ -178,7 +178,7 @@ variable `y` is associated) with the `linkedct:condition` (with which the
 variable `x` is associated).
 
 For detailed instructions on how to assemble a valid link specification
-and a complete catalogue of all measure types included in LIMES, see [Defining Link Specifications](defining_link_specifications.md)
+and a complete catalogue of all measure types included in LIMES, see [Defining Link Specifications](user_manual/configuration_file/defining_link_specifications.md)
 
 
 ## Execution (optional)


### PR DESCRIPTION
Fix URL to Defining Link Specifications in the documentation that ended in 404