### PR TITLE
Fixed hyperparameter conversion from XML for EAGLE

### DIFF
--- a/limes-core/src/main/java/org/aksw/limes/core/ml/algorithm/Eagle.java
+++ b/limes-core/src/main/java/org/aksw/limes/core/ml/algorithm/Eagle.java
@@ -114,7 +114,7 @@ public class Eagle extends ACoreMLAlgorithm {
         fitness.addToReference(extractPositiveMatches(trainingData));
         fitness.fillCachesIncrementally(trainingData);
 
-        Integer nGen = (Integer) getParameter(GENERATIONS);
+        Integer nGen = Integer.parseInt(getParameter(GENERATIONS).toString());
         
         for (int gen = 1; gen <= nGen; gen++) {
             gp.evolve();
@@ -139,7 +139,7 @@ public class Eagle extends ACoreMLAlgorithm {
             return null;
         }
         
-        Integer nGen = (Integer) getParameter(GENERATIONS);
+        Integer nGen = Integer.parseInt(getParameter(GENERATIONS).toString());
         
         specifications = new LinkedList<LinkSpecification>();
         logger.info("Start learning");
@@ -232,11 +232,11 @@ public class Eagle extends ACoreMLAlgorithm {
         jgapConfig.sC = sourceCache;
         jgapConfig.tC = targetCache;
         
-        jgapConfig.setPopulationSize((Integer) getParameter(POPULATION));
-        jgapConfig.setCrossoverProb((Float) getParameter(CROSSOVER_RATE));
-        jgapConfig.setMutationProb((Float) getParameter(MUTATION_RATE));
-        jgapConfig.setPreservFittestIndividual((Boolean) getParameter(PRESERVE_FITTEST));
-        jgapConfig.setReproductionProb((Float) getParameter(REPRODUCTION_RATE));
+        jgapConfig.setPopulationSize(Integer.parseInt(getParameter(POPULATION).toString()));
+        jgapConfig.setCrossoverProb(Float.parseFloat(getParameter(CROSSOVER_RATE).toString()));
+        jgapConfig.setMutationProb(Float.parseFloat(getParameter(MUTATION_RATE).toString()));
+        jgapConfig.setPreservFittestIndividual(Boolean.parseBoolean(getParameter(PRESERVE_FITTEST).toString()));
+        jgapConfig.setReproductionProb(Float.parseFloat(getParameter(REPRODUCTION_RATE).toString()));
         jgapConfig.setPropertyMapping(pm);
 
         if(trainingData != null) { // supervised
@@ -321,7 +321,7 @@ public class Eagle extends ACoreMLAlgorithm {
             }
         }
         // remember the best
-        if ((Boolean) getParameter(PRESERVE_FITTEST)) {
+        if (Boolean.parseBoolean(getParameter(PRESERVE_FITTEST).toString())) {
             if (allBest == null || fitness.calculateRawFitness(allBest) > fittest) {
                 allBest = bestHere;
                 logger.info("Generation " + gen + " new fittest (" + fittest + ") individual: " + getLinkSpecification(bestHere));
@@ -457,7 +457,7 @@ public class Eagle extends ACoreMLAlgorithm {
             }
         }
 
-        if ((Boolean) getParameter(PRESERVE_FITTEST)) {
+        if (Boolean.parseBoolean(getParameter(PRESERVE_FITTEST).toString())) {
             if (allBest == null || fitness.calculateRawFitness(allBest) > fittest) {
                 allBest = bestHere;
                 logger.info("Generation " + gen + " new fittest (" + fittest + ") individual: " + getLinkSpecification(bestHere));


### PR DESCRIPTION
When running LIMES with an XML config and using the EAGLE algorithm, parsing of the hyperparameters fails because the hyperparameters are handed over as strings and cannot be casted directly into Float/Integer/Boolean. The toString() at the end is for making it compatible with setting the parameter directly via API.

Tested with Windows 10 (2004), Java 11 and the following config for EAGLE:

```
	<MLALGORITHM>
    <NAME>eagle</NAME>
	<TYPE>unsupervised</TYPE>
	<PARAMETER> 
        <NAME>generations</NAME>
        <VALUE>100</VALUE>
    </PARAMETER>
	<PARAMETER> 
        <NAME>population</NAME>
        <VALUE>100</VALUE>
    </PARAMETER>
	<PARAMETER> 
        <NAME>crossover_rate</NAME>
        <VALUE>0.3</VALUE>
    </PARAMETER>
	<PARAMETER> 
        <NAME>preserve_fittest</NAME>
        <VALUE>true</VALUE>
    </PARAMETER>
	</MLALGORITHM>
```