### PR TITLE
Update log4j version

### DIFF
--- a/limes-core/pom.xml
+++ b/limes-core/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.6.1</version>
+            <version>2.17.1</version>
         </dependency>
 
         <dependency>
@@ -102,13 +102,13 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.6.1</version>
+            <version>2.17.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.6.1</version>
+            <version>2.17.1</version>
         </dependency>
 
         <!--<dependency>-->


### PR DESCRIPTION
Update the log4j version to fix several vulnerabilities (See https://logging.apache.org/log4j/2.x/security.html).