### PR TITLE
Speed up tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.2</version>
                     <configuration>
-                        <forkCount>1</forkCount>
+                        <forkCount>4</forkCount>
                         <!--suppress UnresolvedMavenProperty -->
                         <argLine>-Xms256m -Xmx128G</argLine>
                         <testFailureIgnore>false</testFailureIgnore>


### PR DESCRIPTION
Increase surefire plugin fork count from 1 to 4 to speed up unit tests.