### PR TITLE
Fix NoClassDefError.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@ target/
 out/
 nbactions.xml
 
+# Eclipse
+.project
+.classpath
+.settings
+
 # IntelliJ IDEA #
 *.iml
 .idea/
@@ -39,3 +44,7 @@ package-lock.json
 # misc
 release.properties
 cache/
+
+# dependency tree file generiated via `mvn dependency:tree > deptree.txt`
+deptree.txt
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ VOLUME /data
 COPY --from=builder /limes/limes.jar limes.jar
 ENV JAVA_OPTS="-Xmx2G"
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "/limes.jar"]
+ENTRYPOINT ["java", "--add-opens", "java.base/java.lang=ALL-UNNAMED", "--add-opens", "java.base/java.lang.invoke=ALL-UNNAMED", "-jar", "/limes.jar"]

--- a/limes-core/pom.xml
+++ b/limes-core/pom.xml
@@ -141,6 +141,23 @@
             <version>4.4.0</version>
             <type>pom</type>
         </dependency>
+        
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-web</artifactId>
+            <version>2.17.1</version>
+            <scope>test</scope>
+        </dependency>
+
+
+		<dependency>
+			<groupId>org.aksw.jenax</groupId>
+			<artifactId>jenax-rx-dataaccess</artifactId>
+			<version>4.4.0-1-SNAPSHOT</version>
+		</dependency>
+
+<!--
         <dependency>
             <groupId>org.aksw.jena-sparql-api</groupId>
             <artifactId>jena-sparql-api-cache-h2</artifactId>
@@ -151,12 +168,6 @@
                     <artifactId>jena-sparql-api-resources-test-config</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-web</artifactId>
-            <version>2.17.1</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.aksw.jena-sparql-api</groupId>
@@ -177,6 +188,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
+-->
 
         <dependency>
             <groupId>org.apache.jena</groupId>

--- a/limes-core/pom.xml
+++ b/limes-core/pom.xml
@@ -99,12 +99,6 @@
             <version>1.7.35</version>
         </dependency>
 
-	   <dependency>
-            <groupId>org.aksw.commons</groupId>
-   			<artifactId>aksw-commons-util</artifactId>
-            <version>0.8.14</version>
-        </dependency>
-
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>

--- a/limes-core/pom.xml
+++ b/limes-core/pom.xml
@@ -148,7 +148,7 @@
 		<dependency>
 			<groupId>org.aksw.jenax</groupId>
 			<artifactId>jenax-rx-dataaccess</artifactId>
-			<version>4.4.0-1-SNAPSHOT</version>
+			<version>4.4.0-1</version>
 		</dependency>
 
 <!--

--- a/limes-core/pom.xml
+++ b/limes-core/pom.xml
@@ -145,11 +145,11 @@
         </dependency>
 
 
-		<dependency>
-			<groupId>org.aksw.jenax</groupId>
-			<artifactId>jenax-rx-dataaccess</artifactId>
-			<version>4.4.0-1</version>
-		</dependency>
+        <dependency>
+            <groupId>org.aksw.jenax</groupId>
+            <artifactId>jenax-rx-dataaccess</artifactId>
+            <version>4.4.0-1</version>
+        </dependency>
 
 <!--
         <dependency>

--- a/limes-core/pom.xml
+++ b/limes-core/pom.xml
@@ -84,19 +84,25 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.6.1</version>
+            <version>2.17.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>log4j-over-slf4j</artifactId>
-            <version>1.7.21</version>
+            <version>1.7.35</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>1.7.21</version>
+            <version>1.7.35</version>
+        </dependency>
+
+	   <dependency>
+            <groupId>org.aksw.commons</groupId>
+   			<artifactId>aksw-commons-util</artifactId>
+            <version>0.8.14</version>
         </dependency>
 
         <dependency>
@@ -132,13 +138,13 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>apache-jena-libs</artifactId>
-            <version>4.2.0</version>
+            <version>4.4.0</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.aksw.jena-sparql-api</groupId>
             <artifactId>jena-sparql-api-cache-h2</artifactId>
-            <version>3.9.0-1</version>
+            <version>3.17.0-1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.aksw.jena-sparql-api</groupId>
@@ -149,13 +155,13 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-web</artifactId>
-            <version>2.6.2</version>
+            <version>2.17.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.aksw.jena-sparql-api</groupId>
             <artifactId>jena-sparql-api-core</artifactId>
-            <version>3.9.0-1</version>
+            <version>3.17.0-1</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-api</artifactId>
@@ -175,7 +181,7 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-core</artifactId>
-            <version>3.9.0</version>
+            <version>4.4.0</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-api</artifactId>
@@ -190,7 +196,7 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-arq</artifactId>
-            <version>3.9.0</version>
+            <version>4.4.0</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-api</artifactId>
@@ -209,7 +215,7 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-jdbc-driver-mem</artifactId>
-            <version>3.6.0</version>
+            <version>4.4.0</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-api</artifactId>
@@ -228,7 +234,7 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-jdbc-driver-remote</artifactId>
-            <version>3.6.0</version>
+            <version>4.4.0</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-api</artifactId>
@@ -247,7 +253,7 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-jdbc-driver-tdb</artifactId>
-            <version>3.6.0</version>
+            <version>4.4.0</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-api</artifactId>
@@ -308,7 +314,11 @@
             <type>jar</type>
             <scope>compile</scope>
         </dependency>
-
+		<dependency>
+		    <groupId>commons-codec</groupId>
+		    <artifactId>commons-codec</artifactId>
+		    <version>1.15</version>
+		</dependency>
         <dependency>
             <groupId>edu.mit</groupId>
             <artifactId>jwi</artifactId>
@@ -335,7 +345,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
         </dependency>
 
         <dependency>
@@ -362,6 +372,10 @@
                 <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>junit-addons</groupId>
+                    <artifactId>junit-addons</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/limes-core/src/main/java/org/aksw/limes/core/controller/Controller.java
+++ b/limes-core/src/main/java/org/aksw/limes/core/controller/Controller.java
@@ -17,7 +17,14 @@
  */
 package org.aksw.limes.core.controller;
 
-import org.aksw.commons.util.Files;
+import static org.fusesource.jansi.Ansi.ansi;
+import static org.fusesource.jansi.Ansi.Color.RED;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.function.Function;
+
 import org.aksw.limes.core.evaluation.oracle.OracleFactory;
 import org.aksw.limes.core.exceptions.UnsupportedMLImplementationException;
 import org.aksw.limes.core.execution.engine.ExecutionEngineFactory;
@@ -35,17 +42,15 @@ import org.aksw.limes.core.io.preprocessing.Preprocessor;
 import org.aksw.limes.core.io.serializer.ISerializer;
 import org.aksw.limes.core.io.serializer.SerializerFactory;
 import org.aksw.limes.core.measures.mapper.MappingOperations;
-import org.apache.commons.cli.*;
+import org.apache.commons.cli.BasicParser;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang3.time.StopWatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.function.Function;
-
-import static org.fusesource.jansi.Ansi.Color.RED;
-import static org.fusesource.jansi.Ansi.ansi;
 
 /**
  * This is the default LIMES Controller used to run the software as CLI.
@@ -116,9 +121,9 @@ public class Controller {
                         format = cmd.getOptionValue('F');
                     }
                     AMapping reference = OracleFactory.getOracle(cmd.getOptionValue('g'), format, "simple").getMapping();
-                    Files.writeToFile(statFile, result.getStatistics(reference), false);
+                    Files.writeString(statFile.toPath(), result.getStatistics(reference));
                 } else {
-                    Files.writeToFile(statFile, result.getStatistics(), false);
+                    Files.writeString(statFile.toPath(), result.getStatistics());
                 }
             } catch (IOException e) {
                 logger.error("Error writing JSON statistics file:");
@@ -204,7 +209,7 @@ public class Controller {
             sourceCache = getSubCache.apply(sourceCache);
             targetCache = getSubCache.apply(targetCache);
         }
-        // 4. Apply preprocessing 
+        // 4. Apply preprocessing
         sourceCache = Preprocessor.applyFunctionsToCache(sourceCache, config.getSourceInfo().getFunctions());
         targetCache = Preprocessor.applyFunctionsToCache(targetCache, config.getTargetInfo().getFunctions());
 

--- a/limes-core/src/main/java/org/aksw/limes/core/io/query/FileQueryModule.java
+++ b/limes-core/src/main/java/org/aksw/limes/core/io/query/FileQueryModule.java
@@ -21,7 +21,7 @@ import org.aksw.limes.core.io.cache.ACache;
 import org.aksw.limes.core.io.config.KBInfo;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.RDFReader;
+import org.apache.jena.rdf.model.RDFReaderI;
 import org.apache.jena.riot.RiotNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,7 +60,7 @@ public class FileQueryModule implements IQueryModule {
                     logger.error(MarkerFactory.getMarker("FATAL"),"endpoint could not be loaded as a file or resource");
                     throw new RuntimeException(e);
                 }
-                RDFReader r = model.getReader(kb.getType());
+                RDFReaderI r = model.getReader(kb.getType());
                 InputStreamReader reader = new InputStreamReader(in, "UTF8");
                 r.read(model, reader, null);
                 reader.close();

--- a/limes-core/src/main/java/org/aksw/limes/core/io/query/ResilientSparqlQueryModule.java
+++ b/limes-core/src/main/java/org/aksw/limes/core/io/query/ResilientSparqlQueryModule.java
@@ -25,10 +25,6 @@ import java.util.concurrent.TimeUnit;
 import org.aksw.commons.io.cache.AdvancedRangeCacheConfigImpl;
 import org.aksw.commons.io.util.PathUtils;
 import org.aksw.commons.io.util.UriToPathUtils;
-import org.aksw.commons.store.object.key.api.ObjectStore;
-import org.aksw.commons.store.object.key.impl.KryoUtils;
-import org.aksw.commons.store.object.key.impl.ObjectStoreImpl;
-import org.aksw.commons.store.object.path.impl.ObjectSerializerKryo;
 import org.aksw.jena_sparql_api.cache.advanced.QueryExecutionFactoryRangeCache;
 import org.aksw.jena_sparql_api.core.FluentQueryExecutionFactory;
 import org.aksw.jena_sparql_api.core.SparqlServiceReference;
@@ -36,7 +32,9 @@ import org.aksw.jena_sparql_api.pagination.core.QueryExecutionFactoryPaginated;
 import org.aksw.jenax.arq.connection.core.QueryExecutionFactory;
 import org.aksw.limes.core.io.cache.ACache;
 import org.aksw.limes.core.io.config.KBInfo;
+import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryFactory;
 import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.sparql.core.DatasetDescription;
@@ -86,7 +84,8 @@ public class ResilientSparqlQueryModule extends SparqlQueryModule implements IQu
      */
     public void fillCache(ACache cache, boolean sparql) {
         long startTime = System.currentTimeMillis();
-        String query = generateQuery();
+        String queryStr = generateQuery();
+        Query query = QueryFactory.create(queryStr);
 
         logger.info("Querying the endpoint.");
         //run query

--- a/limes-core/src/main/java/org/aksw/limes/core/io/query/ResilientSparqlQueryModule.java
+++ b/limes-core/src/main/java/org/aksw/limes/core/io/query/ResilientSparqlQueryModule.java
@@ -175,22 +175,23 @@ public class ResilientSparqlQueryModule extends SparqlQueryModule implements IQu
             // Javaify the endpoint url - e.g. http://dbpedia.org/sparql becomes org/dbepdia/sparql
             String[] pathSegments = UriToPathUtils.toPathSegments(kbInfo.getEndpoint());
             Path cacheFolder = PathUtils.resolve(Paths.get(cacheDirectory), pathSegments);
-            ObjectStore objectStore = ObjectStoreImpl.create(cacheFolder, ObjectSerializerKryo.create(KryoUtils.createKryoPool(null)));
 
             AdvancedRangeCacheConfigImpl cacheConfig = AdvancedRangeCacheConfigImpl.createDefault();
             cacheConfig.setMaxRequestSize(pageSize > 0 ? pageSize : Integer.MAX_VALUE);
-            qef = new QueryExecutionFactoryRangeCache(qef, objectStore, 100, cacheConfig);
+
+            qef = QueryExecutionFactoryRangeCache.create(qef, cacheFolder, 100, cacheConfig);
         } else {
             logger.info("The cache directory has not been set. Creating an uncached SPARQL client.");
         }
 
-        try {
-            qef = new QueryExecutionFactoryPaginated(qef, pageSize);
-            return qef;
-        } catch (Exception e) {
-            logger.warn("Couldn't create Factory with pagination. Returning Factory without pagination. Exception: " +
-                    e.getLocalizedMessage());
-            return qef;
-        }
+        return qef;
+//        try {
+//            qef = new QueryExecutionFactoryPaginated(qef, pageSize);
+//            return qef;
+//        } catch (Exception e) {
+//            logger.warn("Couldn't create Factory with pagination. Returning Factory without pagination. Exception: " +
+//                    e.getLocalizedMessage());
+//            return qef;
+//        }
     }
 }

--- a/limes-core/src/test/java/org/aksw/limes/core/measures/mapper/string/JaroWinklerMapperTest.java
+++ b/limes-core/src/test/java/org/aksw/limes/core/measures/mapper/string/JaroWinklerMapperTest.java
@@ -17,17 +17,19 @@
  */
 package org.aksw.limes.core.measures.mapper.string;
 
-import org.aksw.commons.util.StopWatch;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
 import org.aksw.limes.core.io.mapping.AMapping;
 import org.aksw.limes.core.measures.mapper.MapperTest;
 import org.aksw.limes.core.measures.mapper.MappingOperations;
 import org.aksw.limes.core.measures.measure.string.JaroWinklerMeasure;
 import org.junit.Test;
 
-import java.util.Map;
-import java.util.Set;
-
-import static org.junit.Assert.assertTrue;
+import com.google.common.base.Stopwatch;
 
 /**
  * @author Kevin Dreßler
@@ -44,15 +46,13 @@ public class JaroWinklerMapperTest extends MapperTest {
 //        RatcliffObershelpMapper rom = new RatcliffObershelpMapper();
         Map<String, Set<String>> s = generateRandomMap(sourceSize);
         Map<String, Set<String>> t = generateRandomMap(targetSize);
-        StopWatch stopWatch = new StopWatch();
-        stopWatch.start();
+        Stopwatch stopWatch = Stopwatch.createStarted();
         AMapping m1 = jwm.getMapping(s, t, theta);
 //        AMapping m1 = rom.getMapping(s, t, theta);
 //        stopWatch.getElapsedTime();
         stopWatch.start();
         AMapping m2 = bruteForce(s, t, theta, new JaroWinklerMeasure());
-        stopWatch.getElapsedTime();
-        stopWatch.stop();
+        stopWatch.elapsed(TimeUnit.MILLISECONDS);
         assertTrue(MappingOperations.difference(m1, m2).size() == 0);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,11 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+<!--
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+-->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -91,10 +94,13 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.1</version>
+                    <version>3.8.1</version>
                     <configuration>
+                        <release>${maven.compiler.release}</release>
+<!--
                         <source>${maven.compiler.source}</source>
                         <target>${maven.compiler.target}</target>
+-->
                         <encoding>${project.build.sourceEncoding}</encoding>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Resolves #271 and #272.
Successfully tested with and without docker.
However on Java 16 without docker, the following parameters are needed:

`java --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED -jar ~/mydirectory/limes/limes-core/target/limes-core-1.7.7-SNAPSHOT.jar myfile.xml`

This will not be necessary, when the jena-sparql-api update is published, see <https://github.com/SmartDataAnalytics/jena-sparql-api/issues/43>.