### PR TITLE
Fix GitHub Action JDK test version description.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build on Java ${{ matrix.Java }} (${{ matrix.distribution }})
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ matrix.Java }}
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}


### PR DESCRIPTION
The test actions with JDK 16 were incorrectly titled JDK 11, this pull request fixes that.